### PR TITLE
Fixed error when calling `.decode` with a mask.

### DIFF
--- a/torchcrf/__init__.py
+++ b/torchcrf/__init__.py
@@ -162,8 +162,11 @@ class CRF(nn.Module):
             seq_length = mask_.long().sum()
             best_tags.append(self._viterbi_decode(emission[:seq_length]))
 
-        return torch.tensor(best_tags)
-        # return best_tags
+        if mask is None:
+            return torch.tensor(best_tags)
+        # if we have a mask, then the list of lists won't be a consistent size
+        # and PyTorch will throw an error
+        return best_tags
 
     def _compute_joint_llh(self,
                            emissions: Tensor,


### PR DESCRIPTION
Previously the code attempted to save convert the output tags to a `torch.Tensor`. However, when using a mask, the list of lists cannot be trivially converted to a 2d tensor. Provided a quick fix that simply returns the original list of lists if a mask is applied.

**Note:** This quick fix allows TorchCRF to work with a mask. I can also add a consistent return value in a future pull request if need be (i.e. a padded tensor).